### PR TITLE
add redirect_uri param to refreshAccessToken

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -121,17 +121,9 @@ Strategy.prototype.authenticate = function(req, options) {
       return this.error(new OAuth2Strategy.AuthorizationError(req.query.error_description, req.query.error, req.query.error_uri));
     }
   }
-  
-  var callbackURL = options.callbackURL || this._callbackURL;
-  if (callbackURL) {
-    var parsed = url.parse(callbackURL);
-    if (!parsed.protocol) {
-      // The callback URL is relative, resolve a fully qualified URL from the
-      // URL of the originating request.
-      callbackURL = url.resolve(originalURL(req, { proxy: this._trustProxy }), callbackURL);
-    }
-  }
-  
+
+  var callbackURL = resolveCallbackURL(req, options.callbackURL || this._callbackURL);
+
   if (req.query && req.query.code) {
     var code = req.query.code;
     
@@ -222,8 +214,12 @@ Strategy.prototype.authenticate = function(req, options) {
   }
 };
 
-Strategy.prototype.refreshAccessToken = function(refreshToken, callback) {
-  return this._oauth2.getOAuthJwtAccessToken(refreshToken, { grant_type: 'refresh_token' }, callback);
+Strategy.prototype.refreshAccessToken = function(req, refreshToken, callback) {
+  var params = {
+    grant_type: 'refresh_token',
+    redirect_uri: resolveCallbackURL(req, this._callbackURL)
+  };
+  return this._oauth2.getOAuthJwtAccessToken(refreshToken, params, callback);
 };
 
 function getOAuthJwtAccessToken(code, params, callback) {
@@ -261,6 +257,18 @@ function originalURL(req, options) {
     , protocol = tls ? 'https' : 'http'
     , path = req.url || '';
   return protocol + '://' + host + path;
+}
+
+function resolveCallbackURL(req, callbackURL) {
+  if (req && callbackURL) {
+    var parsed = url.parse(callbackURL);
+    if (!parsed.protocol) {
+      // The callback URL is relative, resolve a fully qualified URL from the
+      // URL of the originating request.
+      callbackURL = url.resolve(originalURL(req, { proxy: this._trustProxy }), callbackURL);
+    }
+  }
+  return callbackURL
 }
 
 /**


### PR DESCRIPTION
the params were missing the redirect_uri and this was causing an error response when trying to use the refresh token

https://docs.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/oauth?view=vsts#refresh-an-expired-access-token